### PR TITLE
Fix wrong `Website` key in `plugin.json` file

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -6,7 +6,7 @@
   "Author": "Garulf",
   "Version": "1.2.2",
   "Language": "executable",
-  "Website": "https://github.com/Garulf/mc_multi_launcher",
+  "Website": "https://github.com/Garulf/MC-Multi-Launcher",
   "IcoPath": "./icon.png",
   "ExecuteFileName": "plugin.exe"
 }


### PR DESCRIPTION
The repo seems to have been renamed since the `Website` key in the `plugin.json` file got updated last